### PR TITLE
Fixing missing default value for brightness

### DIFF
--- a/files/usr/local/lib/python2.7/site-packages/nclock/LedController.py
+++ b/files/usr/local/lib/python2.7/site-packages/nclock/LedController.py
@@ -39,6 +39,7 @@ class LedController(object):
     """ Constructor """
     self._settings = settings
     self._lock     = threading.Lock()
+    self._brightness = 0
 
     # set time and brightness
     self._initialize()


### PR DESCRIPTION
This fixes a bug when reaching line 93 in _set_brightness(): `self._settings.log.msg("LedController: setting brightness to: %d" % self._brightness)` before self._brightness was ever assigned.

```
Traceback (most recent call last):
  File "/usr/local/sbin/nerd-alarmclock.py", line 132, in <module>
    threads = start_threads(settings)
  File "/usr/local/sbin/nerd-alarmclock.py", line 77, in start_threads
    timeKeeperThread = nclock.TimeKeeperThread.TimeKeeperThread(settings)
  File "/usr/local/lib/python2.7/site-packages/nclock/TimeKeeperThread.py", line 35, in __init__
    self._set_day_mode(time.strftime("%H:%M"))
  File "/usr/local/lib/python2.7/site-packages/nclock/TimeKeeperThread.py", line 51, in _set_day_mode
    self._settings.set("_day_mode",new_mode)
  File "/usr/local/lib/python2.7/site-packages/nclock/Settings.py", line 131, in set
    listener(name,old_value,value)
  File "/usr/local/lib/python2.7/site-packages/nclock/LedController.py", line 108, in on_day_mode
    self._set_brightness(value)
  File "/usr/local/lib/python2.7/site-packages/nclock/LedController.py", line 93, in _set_brightness
    self._settings.log.msg("LedController: setting brightness to: %d" % self._brightness)
AttributeError: 'LedController' object has no attribute '_brightness'
```