### PR TITLE
Use simplejson for more descriptive errors

### DIFF
--- a/files/usr/local/lib/python2.7/site-packages/nclock/Settings.py
+++ b/files/usr/local/lib/python2.7/site-packages/nclock/Settings.py
@@ -9,7 +9,7 @@
 #
 # --------------------------------------------------------------------------
 
-import os, json, copy, time
+import os, simplejson, copy, time
 from threading import Thread, Lock, Event
 
 # --- Value holder for shared settings   -----------------------------------
@@ -68,7 +68,7 @@ class Settings(object):
       self.log.msg("Loading settings from %s" % store)
       
     f = open(store,"r")
-    obj = json.load(f)
+    obj = simplejson.load(f)
 
     # convert json-object to settings
     keys = obj.keys()
@@ -101,7 +101,7 @@ class Settings(object):
           jsonobj[key] = "enabled"
 
       self.log.msg("Saving settings to %s" % self._store)
-      json.dump(jsonobj,f,indent=2,sort_keys=True)
+      simplejson.dump(jsonobj,f,indent=2,sort_keys=True)
       f.close()
       self._savelock.release()
     else:

--- a/tools/install
+++ b/tools/install
@@ -9,7 +9,7 @@
 #
 # --------------------------------------------------------------------------
 
-PACKAGES="wiringpi python-pip python-blinkt python-fourletterphat mpg123"
+PACKAGES="wiringpi python-pip python-blinkt python-simplejson python-fourletterphat mpg123"
 PROJECT="nerd-alarmclock"
 
 # --- basic packages   ------------------------------------------------------


### PR DESCRIPTION
See: https://stackoverflow.com/questions/14899506/displaying-better-error-message-than-no-json-object-could-be-decoded